### PR TITLE
refactor: Change close mothod in modal to general method of Element

### DIFF
--- a/client/src/components/basic/Element.js
+++ b/client/src/components/basic/Element.js
@@ -62,4 +62,8 @@ export default class Element {
     this.$el.textContent = text;
     return this;
   }
+
+  removeSelf() {
+    this.getDom().parentNode.removeChild(this.getDom());
+  }
 }

--- a/client/src/components/basic/Modal.js
+++ b/client/src/components/basic/Modal.js
@@ -41,15 +41,11 @@ export default class Modal extends Element {
 
     document.body.appendChild(this.$el);
     this.addEventListener("modalclose", () => {
-      this.close();
+      this.removeSelf();
     });
 
     this.addEventListener("click", () => {
-      this.close();
+      this.removeSelf();
     });
-  }
-
-  close() {
-    document.body.removeChild(this.$el);
   }
 }


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈
- resolved #이슈넘버

## 설명
- 모달 클래스의 close 메소드를 Element 클래스로 옮겼습니다.
- Element.removeSelf() 는 자기 자신을 죽입니다..