### PR TITLE
fix: Remove source map from webpack production config

### DIFF
--- a/client/webpack.config.common.js
+++ b/client/webpack.config.common.js
@@ -62,6 +62,5 @@ module.exports = {
     port: 5500,
     hot: true,
   },
-  devtool: "source-map",
   mode: "development",
 };

--- a/client/webpack.config.dev.js
+++ b/client/webpack.config.dev.js
@@ -2,5 +2,6 @@ const commonConfig = require("./webpack.config.common");
 
 module.exports = {
   ...commonConfig,
+  devtool: "source-map",
   mode: "development",
 };


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 설명
웹펙 공통 설정에 있던 devtool를 development 에서만 적용되게 바꾸었습니다.

## 기타(스크린샷 등)
