### PR TITLE
refactor: TodoDrag 내부 함수 분리, Todo 클릭시 위치 어긋나던 문제 해결

### DIFF
--- a/client/src/components/Todo/Todo.css
+++ b/client/src/components/Todo/Todo.css
@@ -9,6 +9,10 @@
   border-radius: 1rem;
 }
 
+.ghost-todo {
+  margin: 0;
+}
+
 .todo .todo-center,
 .ghost-todo .todo-center {
   display: flex;

--- a/client/src/components/Todo/index.js
+++ b/client/src/components/Todo/index.js
@@ -2,7 +2,7 @@ import Element from "../basic/Element";
 import "./Todo.css";
 import Button from "../basic/Button";
 import ModalTodoEdit from "../ModalTodoEdit";
-import TodoDragController from "../TodoDrag";
+import TodoDrag from "../TodoDrag";
 import LogEvent from "../../lib/LogEvent";
 import api from "../../lib/apiCallWrapper";
 import ModalConfirm from "../basic/ModalConfirm";

--- a/client/src/components/Todo/index.js
+++ b/client/src/components/Todo/index.js
@@ -62,10 +62,10 @@ export default class Todo extends Element {
         else return getTodoDom(dom.parentNode);
       };
       const todoDom = getTodoDom(evt.target);
-      const { top, left, width, height } = todoDom.getBoundingClientRect();
+      const { top, left } = todoDom.getBoundingClientRect();
       const offsetX = evt.clientX - left;
       const offsetY = evt.clientY - top;
-      new TodoDragController(todoDom, offsetX, offsetY);
+      new TodoDrag(todoDom, offsetX, offsetY);
     });
   }
 

--- a/client/src/components/TodoDrag/index.js
+++ b/client/src/components/TodoDrag/index.js
@@ -26,8 +26,8 @@ const getClosestYNextDom = (y, domArray) => {
   return cloesestDom;
 };
 
-const wrapperHandleMousemoveForPlaceHolder = (placeholder) => {
-  const handleMousemoveForPlaceHolder = (evt) => {
+const getHandleMousemoveForPlaceHolder = (placeholder) => {
+  return (evt) => {
     const els = document.elementsFromPoint(evt.clientX, evt.clientY);
     const col = els.filter((node) => node.classList.contains("column"))[0];
     if (!col) return;
@@ -48,18 +48,16 @@ const wrapperHandleMousemoveForPlaceHolder = (placeholder) => {
       );
     }
   };
-  return handleMousemoveForPlaceHolder;
 };
 
-const wrapperHandleMousemove = (dom, offsetX, offsetY) => {
-  const handleMousemove = (evt) => {
+const getHandleMousemove = (dom, offsetX, offsetY) => {
+  return (evt) => {
     setDomTopLeft(dom, evt.clientY - offsetY, evt.clientX - offsetX);
   };
-  return handleMousemove;
 };
 
-const wrapperHandleMouseUp = (ghostNode, placeholder, bodyEvents) => {
-  const handleMouseUp = (evt) => {
+const getHandleMouseUp = (ghostNode, placeholder, bodyEvents) => {
+  return (evt) => {
     ghostNode.classList.remove("ghost-todo");
     ghostNode.classList.add("todo");
 
@@ -71,7 +69,6 @@ const wrapperHandleMouseUp = (ghostNode, placeholder, bodyEvents) => {
       document.body.removeEventListener(evtname, fn);
     });
   };
-  return handleMouseUp;
 };
 
 export default class TodoDrag {
@@ -87,7 +84,7 @@ export default class TodoDrag {
     let bodyEvents = [];
     dom.parentNode.remove(); // remove li from column;
 
-    const handleMousemove = wrapperHandleMousemove(dom, offsetX, offsetY);
+    const handleMousemove = getHandleMousemove(dom, offsetX, offsetY);
     bodyEvents.push(["mousemove", handleMousemove]);
     document.body.addEventListener("mousemove", handleMousemove);
 
@@ -99,17 +96,13 @@ export default class TodoDrag {
 
     document.body.appendChild(ghostNode);
 
-    const handleMousemoveForPlaceHolder = wrapperHandleMousemoveForPlaceHolder(
+    const handleMousemoveForPlaceHolder = getHandleMousemoveForPlaceHolder(
       placeholder
     );
     bodyEvents.push(["mousemove", handleMousemoveForPlaceHolder]);
     document.body.addEventListener("mousemove", handleMousemoveForPlaceHolder);
 
-    const handleMouseUp = wrapperHandleMouseUp(
-      ghostNode,
-      placeholder,
-      bodyEvents
-    );
+    const handleMouseUp = getHandleMouseUp(ghostNode, placeholder, bodyEvents);
     bodyEvents.push(["mouseup", handleMouseUp]);
     document.body.addEventListener("mouseup", handleMouseUp);
   }

--- a/client/src/components/TodoDrag/index.js
+++ b/client/src/components/TodoDrag/index.js
@@ -1,8 +1,80 @@
-import { Element } from "../basic";
 import DragPlaceholder from "./DragPlaceholder";
 import "./TodoDrag.css";
 
-export default class TodoDragController {
+const setDomTopLeft = (dom, top, left) => {
+  dom.style.top = `${top}px`;
+  dom.style.left = `${left}px`;
+};
+
+/**
+ * y 좌표 위 todo 중 y 좌표와 가장 가까운 todo의 dom 반환.
+ * @param {number} y
+ * @param {HTMLElement[]} domArray
+ * @returns null | HTMLElement
+ */
+const getClosestYNextDom = (y, domArray) => {
+  let cloesestDom = null;
+  domArray.some((dom) => {
+    const rectOfDom = dom.getBoundingClientRect();
+    const middleOfDom = (rectOfDom.top + rectOfDom.bottom) / 2;
+    if (middleOfDom < y) {
+      cloesestDom = dom;
+    } else {
+      return true; // some에서 return true는 break 처럼 동작
+    }
+  });
+  return cloesestDom;
+};
+
+const wrapperHandleMousemoveForPlaceHolder = (placeholder) => {
+  const handleMousemoveForPlaceHolder = (evt) => {
+    const els = document.elementsFromPoint(evt.clientX, evt.clientY);
+    const col = els.filter((node) => node.classList.contains("column"))[0];
+    if (!col) return;
+
+    const closestBeforeTodoLi = getClosestYNextDom(
+      evt.clientY,
+      Array.from(col.querySelectorAll("li"))
+    );
+
+    if (!closestBeforeTodoLi) {
+      col
+        .querySelector("ol")
+        .insertAdjacentElement("afterbegin", placeholder.getDom());
+    } else {
+      closestBeforeTodoLi.insertAdjacentElement(
+        "afterend",
+        placeholder.getDom()
+      );
+    }
+  };
+  return handleMousemoveForPlaceHolder;
+};
+
+const wrapperHandleMousemove = (dom, offsetX, offsetY) => {
+  const handleMousemove = (evt) => {
+    setDomTopLeft(dom, evt.clientY - offsetY, evt.clientX - offsetX);
+  };
+  return handleMousemove;
+};
+
+const wrapperHandleMouseUp = (ghostNode, placeholder, bodyEvents) => {
+  const handleMouseUp = (evt) => {
+    ghostNode.classList.remove("ghost-todo");
+    ghostNode.classList.add("todo");
+
+    const li = document.createElement("li");
+    li.appendChild(ghostNode);
+    placeholder.getDom().parentNode.insertBefore(li, placeholder.getDom());
+    placeholder.getDom().remove();
+    bodyEvents.forEach(([evtname, fn]) => {
+      document.body.removeEventListener(evtname, fn);
+    });
+  };
+  return handleMouseUp;
+};
+
+export default class TodoDrag {
   constructor(dom, offsetX, offsetY) {
     const { top, left } = dom.getBoundingClientRect();
 
@@ -14,10 +86,8 @@ export default class TodoDragController {
 
     let bodyEvents = [];
     dom.parentNode.remove(); // remove li from column;
-    const handleMousemove = (evt) => {
-      dom.style.top = `${evt.clientY - offsetY}px`;
-      dom.style.left = `${evt.clientX - offsetX}px`;
-    };
+
+    const handleMousemove = wrapperHandleMousemove(dom, offsetX, offsetY);
     bodyEvents.push(["mousemove", handleMousemove]);
     document.body.addEventListener("mousemove", handleMousemove);
 
@@ -25,68 +95,22 @@ export default class TodoDragController {
 
     ghostNode.classList.add("ghost-todo");
     ghostNode.classList.remove("todo");
-    ghostNode.style.top = `${top}px`;
-    ghostNode.style.left = `${left}px`;
+    setDomTopLeft(ghostNode, top, left);
+
     document.body.appendChild(ghostNode);
 
-    const handleMousemove1 = (evt) => {
-      const els = document.elementsFromPoint(evt.clientX, evt.clientY);
-      const col = els.filter((node) => node.classList.contains("column"))[0];
-      if (!col) return;
+    const handleMousemoveForPlaceHolder = wrapperHandleMousemoveForPlaceHolder(
+      placeholder
+    );
+    bodyEvents.push(["mousemove", handleMousemoveForPlaceHolder]);
+    document.body.addEventListener("mousemove", handleMousemoveForPlaceHolder);
 
-      // 가장 가까운 todo의 다음 dom 반환. insertBefore을 사용하기 위해.
-      /**
-       *
-       * @param {number} y
-       * @param {HTMLElement[]} domArray
-       * @returns null | HTMLElement
-       */
-      const getClosestYNextDom = (y, domArray) => {
-        let cloesestDom = null;
-        domArray.some((dom) => {
-          const rectOfDom = dom.getBoundingClientRect();
-          const middleOfDom = (rectOfDom.top + rectOfDom.bottom) / 2;
-          if (middleOfDom < y) {
-            cloesestDom = dom;
-          } else {
-            return true; // some에서 return true는 break 처럼 동작
-          }
-        });
-        return cloesestDom;
-      };
-
-      const closestBeforeTodoLi = getClosestYNextDom(
-        evt.clientY,
-        Array.from(col.querySelectorAll("li"))
-      );
-
-      if (!closestBeforeTodoLi) {
-        col
-          .querySelector("ol")
-          .insertAdjacentElement("afterbegin", placeholder.getDom());
-      } else {
-        closestBeforeTodoLi.insertAdjacentElement(
-          "afterend",
-          placeholder.getDom()
-        );
-      }
-    };
-    bodyEvents.push(["mousemove", handleMousemove1]);
-    document.body.addEventListener("mousemove", handleMousemove1);
-
-    const handleMouseUP = (evt) => {
-      ghostNode.classList.remove("ghost-todo");
-      ghostNode.classList.add("todo");
-
-      const li = document.createElement("li");
-      li.appendChild(ghostNode);
-      placeholder.getDom().parentNode.insertBefore(li, placeholder.getDom());
-      placeholder.getDom().remove();
-      bodyEvents.forEach(([evtname, fn]) => {
-        document.body.removeEventListener(evtname, fn);
-      });
-    };
-    bodyEvents.push(["mouseup", handleMouseUP]);
-    document.body.addEventListener("mouseup", handleMouseUP);
+    const handleMouseUp = wrapperHandleMouseUp(
+      ghostNode,
+      placeholder,
+      bodyEvents
+    );
+    bodyEvents.push(["mouseup", handleMouseUp]);
+    document.body.addEventListener("mouseup", handleMouseUp);
   }
 }


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 설명
- TodoDrag constructor에 정의된 함수들을 클래스 밖으로 분리했습니다.
- Todo 카드 클릭시 반투명 카드의 위치가 어긋나던 문제 해결했습니다.
