### PR TITLE
fix: textarea 크기 조절할때 레이아웃 깨지는 문제 수정했습니다.

### DIFF
--- a/client/src/components/Column/Column.scss
+++ b/client/src/components/Column/Column.scss
@@ -31,7 +31,7 @@
   }
 
   .column-todos-wrapper {
-    height: calc(100% - 20px - 138px);
+    height: calc(100% - 20px);
     overflow: auto;
   }
 }

--- a/client/src/components/Column/index.js
+++ b/client/src/components/Column/index.js
@@ -60,11 +60,12 @@ export default class Column extends Element {
     header.appendChild(headerRight);
     this.appendChild(header);
 
+    const todosWrapper = new Element("div", { class: "column-todos-wrapper" });
+
     this.$newTodoForm = new NewTodoForm(id, this.addTodo.bind(this));
-    this.appendChild(this.$newTodoForm);
+    todosWrapper.appendChild(this.$newTodoForm);
 
     this.$todos = new List(true);
-    const todosWrapper = new Element("div", { class: "column-todos-wrapper" });
     todosWrapper.appendChild(this.$todos);
     this.appendChild(todosWrapper);
 

--- a/client/src/components/global.scss
+++ b/client/src/components/global.scss
@@ -100,3 +100,7 @@
 .display-none {
   display: none;
 }
+
+textarea {
+  max-height: 400px;
+}


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈
- resolved #58 

## 설명
todo add form을 todo wrapper 안으로 넣었습니다.
todo wrapper는 overflow : auto 속성이 있어서 컨텐츠가 레이아웃 밖으로 나가지 않습니다.

## 기타(스크린샷 등)
<img src="https://user-images.githubusercontent.com/32071079/88153324-36f1a200-cc40-11ea-8d07-babd2392062e.png" width="400px">
