### PR TITLE
fix: 로그에서 한 달 작게 나오는 문제 해결

### DIFF
--- a/client/src/components/Log/index.js
+++ b/client/src/components/Log/index.js
@@ -3,7 +3,9 @@ import "./Log.css";
 
 function formatDatetime(str) {
   const date = new Date(str);
-  return `${date.getFullYear()}/${date.getMonth()}/${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
+  return `${date.getFullYear()}/${
+    date.getMonth() + 1
+  }/${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
 }
 
 export default class Log extends Element {


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 관련 이슈
- resolved #이슈넘버

## 설명
getMonth() 의 리턴  범위 0 ~ 11이므로 +1을 해줘야 합니다.