### PR TITLE
fix: menu 타이틀은 스크롤이 있어도 항상 보이게

### DIFF
--- a/client/src/components/Menu/Menu.css
+++ b/client/src/components/Menu/Menu.css
@@ -49,3 +49,7 @@
   color: black;
   font-weight: bold;
 }
+.menu .logs-wrapper {
+  height: 100%;
+  overflow: auto;
+}

--- a/client/src/components/Menu/index.js
+++ b/client/src/components/Menu/index.js
@@ -61,13 +61,15 @@ export default class Menu extends Element {
       text: "🔔 Activity",
     });
     this.appendChild(activityTitle);
+    const logsWrapper = new Element("div", { class: "logs-wrapper" });
     this.$logs = new List(true);
-    this.appendChild(this.$logs);
     api.loadLogsApi().then((res) => {
       res.forEach(({ action_type, data }) => {
         this.log(action_type, data);
       });
     });
+    logsWrapper.appendChild(this.$logs);
+    this.appendChild(logsWrapper);
   }
 
   setHidden(flag) {


### PR DESCRIPTION
## 체크리스트
- [x] 파일명/폴더명
- [x] 브랜치명
- [x] 코드를 실행했을 때 잘 동작하는 코드인지 확인
- [x] 코드 포맷팅 확인
- [x] 관련된 label 추가했는지 확인

## 설명
menu, activity는 항상 보입니다.